### PR TITLE
Fix missing include wich make problem during compilation.

### DIFF
--- a/src/Mesh.hpp
+++ b/src/Mesh.hpp
@@ -25,7 +25,7 @@
 
 #include <cstdint>
 #include <vector>
-
+#include <cstring>
 #include "types.hpp"
 #include "CTBException.hpp"
 


### PR DESCRIPTION
I fixed missing include, wich make problem during compilation on Ubuntu. I got error 
/cesium-terrain-builder/src/Mesh.hpp:64:39: error: 'memset' was not declared in this scop memset(wktText, 0, sizeof(wktText));
This change solve the problem.