### PR TITLE
Support GDAL > 3.0 (Traditional GIS-friendly axis order)

### DIFF
--- a/src/GDALTiler.cpp
+++ b/src/GDALTiler.cpp
@@ -68,7 +68,9 @@ GDALTiler::GDALTiler(GDALDataset *poDataset, const Grid &grid, const TilerOption
       throw CTBException("The source dataset does not have a spatial reference system assigned");
 
     OGRSpatialReference srcSRS = OGRSpatialReference(srcWKT);
+    srcSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     OGRSpatialReference gridSRS = mGrid.getSRS();
+    gridSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
 
     if (!srcSRS.IsSame(&gridSRS)) { // it doesn't match
       // Check the srs is valid

--- a/src/GDALTiler.cpp
+++ b/src/GDALTiler.cpp
@@ -68,9 +68,12 @@ GDALTiler::GDALTiler(GDALDataset *poDataset, const Grid &grid, const TilerOption
       throw CTBException("The source dataset does not have a spatial reference system assigned");
 
     OGRSpatialReference srcSRS = OGRSpatialReference(srcWKT);
-    srcSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     OGRSpatialReference gridSRS = mGrid.getSRS();
+
+    #if ( GDAL_VERSION_MAJOR >= 3 )
+    srcSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     gridSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+    #endif
 
     if (!srcSRS.IsSame(&gridSRS)) { // it doesn't match
       // Check the srs is valid

--- a/src/GlobalGeodetic.cpp
+++ b/src/GlobalGeodetic.cpp
@@ -27,6 +27,7 @@ using namespace ctb;
 static OGRSpatialReference
 setSRS(void) {
   OGRSpatialReference srs;
+  srs.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
   srs.importFromEPSG(4326);
   return srs;
 }

--- a/src/GlobalGeodetic.cpp
+++ b/src/GlobalGeodetic.cpp
@@ -27,7 +27,11 @@ using namespace ctb;
 static OGRSpatialReference
 setSRS(void) {
   OGRSpatialReference srs;
+  
+  #if ( GDAL_VERSION_MAJOR >= 3 )
   srs.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+  #endif
+  
   srs.importFromEPSG(4326);
   return srs;
 }

--- a/src/GlobalMercator.cpp
+++ b/src/GlobalMercator.cpp
@@ -34,7 +34,11 @@ const double GlobalMercator::cOriginShift = GlobalMercator::cEarthCircumference 
 static OGRSpatialReference
 setSRS(void) {
   OGRSpatialReference srs;
+  
+  #if ( GDAL_VERSION_MAJOR >= 3 )
   srs.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+  #endif
+  
   srs.importFromEPSG(3857);
   return srs;
 }

--- a/src/GlobalMercator.cpp
+++ b/src/GlobalMercator.cpp
@@ -34,6 +34,7 @@ const double GlobalMercator::cOriginShift = GlobalMercator::cEarthCircumference 
 static OGRSpatialReference
 setSRS(void) {
   OGRSpatialReference srs;
+  srs.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
   srs.importFromEPSG(3857);
   return srs;
 }

--- a/src/Grid.hpp
+++ b/src/Grid.hpp
@@ -68,7 +68,9 @@ public:
     mYOriginShift(extent.getHeight() / 2),
     mZoomFactor(zoomFactor)
   {
+    #if ( GDAL_VERSION_MAJOR >= 3 )
     mSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+    #endif
   }
 
   /// Overload the assignment operator

--- a/src/Grid.hpp
+++ b/src/Grid.hpp
@@ -67,7 +67,9 @@ public:
     mXOriginShift(extent.getWidth() / 2),
     mYOriginShift(extent.getHeight() / 2),
     mZoomFactor(zoomFactor)
-  {}
+  {
+    mSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+  }
 
   /// Overload the assignment operator
   Grid &

--- a/src/TerrainTile.cpp
+++ b/src/TerrainTile.cpp
@@ -324,7 +324,11 @@ TerrainTile::heightsToRaster() const {
 
   // Create the spatial reference system for the raster
   OGRSpatialReference oSRS;
+
+  #if ( GDAL_VERSION_MAJOR >= 3 )
   oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+  #endif
+
   if (oSRS.importFromEPSG(4326) != OGRERR_NONE) {
     throw CTBException("Could not create EPSG:4326 spatial reference");
   }

--- a/src/TerrainTile.cpp
+++ b/src/TerrainTile.cpp
@@ -324,6 +324,7 @@ TerrainTile::heightsToRaster() const {
 
   // Create the spatial reference system for the raster
   OGRSpatialReference oSRS;
+  oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
   if (oSRS.importFromEPSG(4326) != OGRERR_NONE) {
     throw CTBException("Could not create EPSG:4326 spatial reference");
   }

--- a/tools/ctb-tile.cpp
+++ b/tools/ctb-tile.cpp
@@ -523,6 +523,7 @@ createEmptyRootElevationFile(std::string &fileName, const Grid &grid, const Tile
 
   // Create the spatial reference system for the file
   OGRSpatialReference oSRS;
+  oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
   if (oSRS.importFromEPSG(4326) != OGRERR_NONE) {
     throw CTBException("Could not create EPSG:4326 spatial reference");
   }

--- a/tools/ctb-tile.cpp
+++ b/tools/ctb-tile.cpp
@@ -523,7 +523,11 @@ createEmptyRootElevationFile(std::string &fileName, const Grid &grid, const Tile
 
   // Create the spatial reference system for the file
   OGRSpatialReference oSRS;
+
+  #if ( GDAL_VERSION_MAJOR >= 3 )
   oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+  #endif
+  
   if (oSRS.importFromEPSG(4326) != OGRERR_NONE) {
     throw CTBException("Could not create EPSG:4326 spatial reference");
   }


### PR DESCRIPTION
From GDAL > 3.0, axis order has been changed. Thus, to support GDAL > 3.0 in `ctb-tile` or other commands, we have to retain traditional GIS-friendly axis order in OGRSpatialReference object.

It can be achieved by `OGRSpatialReference::SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);`

## Changes
- Update `gdaloverviewdataset.cpp` to v3.1.0's one.
- `SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER)` for all OGRSpatialReference object with pre-processor to check if `GDAL_VERSION` > 3.0.

## How this has been tested?
Before this commit, if you run `ctb-tile` with cesium-friendly option, you can see cesium-friendly root terrains are not generated. It's error because axis order was messed up. With retaining traditional GIS-friendly axis order, every root terrains and `layer.json` are generated with no problems.