### PR TITLE
Fix coordinate transformation in GDALTiler constructor to correctly handle axis order for latitude and longitude.

### DIFF
--- a/src/GDALTiler.cpp
+++ b/src/GDALTiler.cpp
@@ -69,6 +69,10 @@ GDALTiler::GDALTiler(GDALDataset *poDataset, const Grid &grid, const TilerOption
 
     OGRSpatialReference srcSRS = OGRSpatialReference(srcWKT);
     OGRSpatialReference gridSRS = mGrid.getSRS();
+    // set the axis mapping strategy to traditional GIS order 
+    // https://gis.stackexchange.com/questions/421771/ogr-coordinatetransformation-appears-to-be-inverting-xy-coordinates
+    gridSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+    srcSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
 
     if (!srcSRS.IsSame(&gridSRS)) { // it doesn't match
       // Check the srs is valid


### PR DESCRIPTION
Set the axis mapping strategy to traditional GIS order, See this link...[this](https://gis.stackexchange.com/questions/421771/ogr-coordinatetransformation-appears-to-be-inverting-xy-coordinates)
If this is not configured, when performing WGS84（4326） to Mercator（3857） coordinate transformation, the program will report errors .
Like this:
ERROR 1: PROJ: webmerc: Invalid latitude
ERROR 1: PROJ: webmerc: Invalid latitude
ERROR 1: PROJ: webmerc: Invalid latitude
ERROR 1: PROJ: webmerc: Invalid latitude
Error: Could not transform dataset bounds to tile spatial reference system.